### PR TITLE
Add GSoC issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/gsoc-project.md
+++ b/.github/ISSUE_TEMPLATE/gsoc-project.md
@@ -1,0 +1,38 @@
+---
+name: GSoC Project Idea
+about: "Project idea for students applying to Google Summer of Code"
+title: ''
+labels: 'GSoC'
+assignees: ''
+
+---
+
+<!-- Please feel free to propose your own project using this template. Cantera developers will assist in refining the project idea once the issue is created. -->
+
+**Idea**
+
+<!-- A brief description of the project. Make sure to address:
+
+* What problem is it trying to solve?
+* What are possible solutions?
+-->
+
+
+**Difficulty**
+
+<!-- Provide your best estimate at difficulty level: e.g. Easy / Medium / Hard -->
+
+
+**Required Knowledge**
+
+<!-- Provide details on required knowledge: e.g. Python / C++ / etc. -->
+
+
+**Mentors**
+
+<!-- Github handle of project mentor -->
+
+
+**References**
+
+<!-- Links to related Pull Requests, GitHub Issues, Users' Group topics, or other relevant material. -->


### PR DESCRIPTION
Adding template for GSoC Ideas to this repository is intended to improve visibility. 

The format follows [GSoC Ideas](https://github.com/Cantera/cantera/wiki/GSoC-2020-Ideas) on the wiki page.